### PR TITLE
Update junit:junit from 4.4 to 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.4</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
I determined that `junit:junit` could be updated from `4.4` to `4.13.2`.

:warning: **Please ensure that this change does not break your build before merging!** :warning: